### PR TITLE
Replaced Buffer with TextEncoder

### DIFF
--- a/src/base32.ts
+++ b/src/base32.ts
@@ -76,7 +76,8 @@ export function decode(s: string): Uint8Array {
     throw new Error("Invalid length");
   }
 
-  const v: Uint8Array = Buffer.from(s);
+  const encoder = new TextEncoder();
+  const v: Uint8Array = encoder.encode(s);
 
   // Check if all the characters are part of the expected base32 character set.
   if (


### PR DESCRIPTION
This resolves the issue identified in #3 

Buffer only works in Node, whereas TextEncoder works in Browser and Edge runtimes.

It's a tiny change and the existing tests passed. Also tested it on Edge runtime and it works.

Hope this is okay.